### PR TITLE
Dump download url if append mode is enabled for resource datastore

### DIFF
--- a/ckanext/aircan_connector/templates/package/resource_read.html
+++ b/ckanext/aircan_connector/templates/package/resource_read.html
@@ -1,0 +1,63 @@
+{% ckan_extends %}
+
+{% block resource_actions_inner %}
+{% if h.check_access('package_update', {'id':pkg.id }) %}
+  <li>{% link_for _('Manage'), controller='package', action='resource_edit', id=pkg.name, resource_id=res.id, class_='btn btn-default', icon='wrench' %}</li>
+{% endif %}
+{% if res.url and h.is_url(res.url) %}
+  <li>
+    <div class="btn-group">
+        <!-- Replace download url for datastore append enable resource-->
+      {% if res.datastore_append_or_update %}
+        {% set res_url = h.url_for( controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, qualified=True) %}
+        <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res_url }}">
+      {% else %}
+         <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+      {% endif %}
+      {% if res.resource_type in ('listing', 'service') %}
+        <i class="fa fa-eye"></i> {{ _('View') }}
+      {% elif  res.resource_type == 'api' %}
+        <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+      {% elif (not res.has_views or not res.can_be_previewed) and not res.url_type == 'upload' %}
+        <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
+      {% else %}
+        <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
+      {% endif %}
+    </a>
+     {% block download_resource_button %}
+      {%if res.datastore_active %}
+    <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+        <span class="caret"></span>
+      </button>
+    <ul class="dropdown-menu">
+      <li>
+        <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, bom=True) }}"
+          target="_blank"><span>CSV</span></a>
+        <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='tsv', bom=True) }}"
+          target="_blank"><span>TSV</span></a>
+        <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='json') }}"
+          target="_blank"><span>JSON</span></a>
+        <a href="{{ h.url_for(controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, format='xml') }}"
+          target="_blank"><span>XML</span></a>
+      </li>
+    </ul>
+    {%endif%} {% endblock %}
+    </div>
+  </li>
+{% endif %}
+{% endblock %}
+
+
+{% block resource_read_url %}
+    <!-- Replace download url for datastore append enable resource-->
+    {% if res.datastore_append_or_update %}
+    {% set res_url = h.url_for( controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, qualified=True) %}
+    <p class="text-muted ellipsis">{{ _('URL:') }}<a class="resource-url-analytics" href="{{ res_url }}"  title="{{ res_url }}">{{  res_url }}</a></p>
+    {% else %}
+        {% if res.url and h.is_url(res.url) %}
+        <p class="text-muted ellipsis">{{ _('URL:') }}<a class="resource-url-analytics" href="{{ res.url }}" title="{{ res.url }}">{{ res.url }}</a></p>
+        {% elif res.url %}
+        <p class="text-muted break-word">{{ _('URL:') }} {{ res.url }}</p>
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/ckanext/aircan_connector/templates/package/snippets/resource_item.html
+++ b/ckanext/aircan_connector/templates/package/snippets/resource_item.html
@@ -1,0 +1,42 @@
+{% ckan_extends %}
+
+{% block resource_item_explore_links %}
+      <li>
+        <a href="{{ url }}">
+          {% if res.has_views %}
+            <i class="fa fa-bar-chart-o"></i>
+            {{ _('Preview') }}
+          {% else %}
+            <i class="fa fa-info-circle"></i>
+            {{ _('More information') }}
+          {% endif %}
+        </a>
+      </li>
+      {% if res.url and h.is_url(res.url) %}
+      <li>
+        <!-- Replace download url for datastore append enable resource-->
+        {% if res.datastore_append_or_update %}
+        {% set res_url = h.url_for( controller='ckanext.datastore.controller:DatastoreController', action='dump', resource_id=res.id, qualified=True) %}
+          <a href="{{ res_url }}" class="resource-url-analytics" target="_blank">
+        {% else %}
+          <a href="{{ res.url }}" class="resource-url-analytics" target="_blank">
+        {% endif %}
+          {% if res.has_views or res.url_type == 'upload' %}
+            <i class="fa fa-arrow-circle-o-down"></i>
+            {{ _('Download') }}
+          {% else %}
+            <i class="fa fa-external-link"></i>
+            {{ _('Go to resource') }}
+          {% endif %}
+        </a>
+      </li>
+      {% endif %}
+      {% if can_edit %}
+      <li>
+        <a href="{{ h.url_for(controller='package', action='resource_edit', id=pkg.name, resource_id=res.id) }}">
+          <i class="fa fa-pencil-square-o"></i>
+          {{ _('Edit') }}
+        </a>
+      </li>
+      {% endif %}
+      {% endblock %}


### PR DESCRIPTION
When datafile is appended it just updates the rows but when the user tires to download the file it just downloads the most recent file. 
URL should be datastore dump url so rasing PR for that. 