### PR TITLE
fix(plugin): dedupe duplicate aircan submit within a request (UNTESTED)

### DIFF
--- a/ckanext/aircan/plugin.py
+++ b/ckanext/aircan/plugin.py
@@ -1,6 +1,7 @@
 import logging
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as tk
+import ckan.model as model
 from ckan.model.domain_object import DomainObjectOperation
 from ckan.model.resource import Resource
 
@@ -88,6 +89,24 @@ class AircanPlugin(plugins.SingletonPlugin):
             last_modified_changed = bool(history.added)
             if not (url_changed or last_modified_changed):
                 return
+
+        # Deduplicate within a single request. A create-with-upload reaches this
+        # hook twice for the same resource — once as `new`, then as `changed`
+        # (url / last_modified set during the same request) — and each call would
+        # fire the aircan DAG, double-loading the data into the datastore. The two
+        # calls arrive on separate commits of the same request-scoped SQLAlchemy
+        # session, so a marker on Session.info (discarded when the session is
+        # torn down at end of request) collapses them to a single submit. This
+        # deliberately stays in the model layer rather than using flask.g, so it
+        # also covers non-Flask callers (CLI, tests).
+        submitted = model.Session.info.setdefault("_aircan_submitted_ids", set())
+        if entity.id in submitted:
+            log.debug(
+                "Skipping duplicate aircan submit for %s in this request",
+                entity.id,
+            )
+            return
+        submitted.add(entity.id)
 
         context = {
             "ignore_auth": True,

--- a/ckanext/aircan/plugin.py
+++ b/ckanext/aircan/plugin.py
@@ -99,7 +99,12 @@ class AircanPlugin(plugins.SingletonPlugin):
         # torn down at end of request) collapses them to a single submit. This
         # deliberately stays in the model layer rather than using flask.g, so it
         # also covers non-Flask callers (CLI, tests).
-        submitted = model.Session.info.setdefault("_aircan_submitted_ids", set())
+        # `model.Session()` returns the current request-scoped Session instance;
+        # `.info` is a real per-session dict (avoids relying on scoped_session
+        # attribute proxying) and survives commits within the request.
+        submitted = model.Session().info.setdefault(
+            "_aircan_submitted_ids", set()
+        )
         if entity.id in submitted:
             log.debug(
                 "Skipping duplicate aircan submit for %s in this request",


### PR DESCRIPTION
> ⚠️ **NOT TESTED.** Written without a running CKAN stack — `IDomainObjectModification`
> hook firing can't be exercised locally. Please validate on a real stack before merging
> (steps below). Branched off **`feat/airflow-v3-support`** (the commit `5171c1f` currently
> deployed to dev), **not** `master` — `master` has the `ckanext/aircan_connector` restructure
> that isn't on dev.

## The issue
A **create-with-upload doubles the ingested data** on append/upsert (e.g. a 3-row file lands
as 6 rows). Replace masks it — two truncating loads leave one copy — so it only shows on
append/upsert.

Root cause: for a single `resource_create`, `IDomainObjectModification.notify` fires **twice**
for the same resource in one request:
1. `operation == new` (resource inserted), and
2. `operation == changed` (its `url` / `last_modified` are set during the same request).

Both pass the `changed`-guard and call `_self_aircan_submit`, so the Airflow DAG runs **twice**
→ the file is loaded twice.

We confirmed this on dev:
- Add-resource **append** of a 3-row CSV → **6 rows** (`1,1,2,2,3,3`).
- Same file via **onboarding** (`package_create`, one domain modification) → **3 rows**.
- The frontend also had a second, cross-request trigger (`resource_create` then
  `resource_patch(url)`); that half is fixed separately in the frontend (collapse to a single
  `resource_create`). This PR addresses the **within-request** half.

## The proposed fix
Deduplicate within a single request. The two `notify` calls arrive on separate commits of the
**same request-scoped SQLAlchemy session**, so a marker on `model.Session.info` (keyed by
resource id, discarded when the session is torn down at end of request) collapses them to a
single submit.

```python
submitted = model.Session.info.setdefault("_aircan_submitted_ids", set())
if entity.id in submitted:
    return
submitted.add(entity.id)
```

Deliberately **not** `flask.g` — kept in the model layer so CLI/test callers are covered too,
and it needs no request context.

## How to validate (on a running CKAN stack)
1. Create a resource with a CSV upload in **append** mode (3 rows).
2. After ingestion, `datastore_search?resource_id=…&limit=0` → **3 rows** (was 6 before).
3. A normal single-file edit still re-ingests once (append adds rows, replace truncates).
4. Check logs for `Skipping duplicate aircan submit for <id> in this request` on the create.

## Scope / notes
- One file changed: `ckanext/aircan/plugin.py` (import `ckan.model`, guard in `notify`).
- No behavioural change to *which* events trigger ingestion — only collapses the duplicate.
- Pairs with the frontend create-collapse (already in the dx-helm-neso PR) to fully close the
  duplication on the add-resource path.
