### PR TITLE
feat(plugin): lock existing column types on append/upsert (API enforcement)

### DIFF
--- a/ckanext/aircan/plugin.py
+++ b/ckanext/aircan/plugin.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 
@@ -13,12 +14,62 @@ from ckanext.aircan import interfaces
 
 log = logging.getLogger(__name__)
 
+# Ingestion modes that load into the *existing* datastore/BigQuery table rather
+# than rebuilding it. For these, an existing column's type cannot change:
+# BigQuery cannot re-type a column in place, that is only possible with a full
+# "replace" (which rebuilds the table).
+_TYPE_LOCKING_MODES = ("append", "upsert")
+
+
+def _parse_schema(schema):
+    """Return a Table Schema descriptor as a dict, or None when there is
+    nothing to inspect. Accepts either a dict or a JSON string (both occur
+    depending on the caller)."""
+    if not schema:
+        return None
+    if isinstance(schema, str):
+        try:
+            schema = json.loads(schema)
+        except (ValueError, TypeError):
+            return None
+    if not isinstance(schema, dict):
+        return None
+    return schema
+
+
+def _fields_by_name(schema):
+    """Map trimmed field name -> field dict for a parsed schema descriptor."""
+    by_name = {}
+    for field in schema.get("fields") or []:
+        if not isinstance(field, dict):
+            continue
+        name = (field.get("name") or "").strip()
+        if name:
+            by_name[name] = field
+    return by_name
+
+
+def _retyped_columns(stored_schema, incoming_schema):
+    """Names of columns present in both schemas whose declared ``type`` differs.
+    New columns (absent from the stored schema) are ignored — they can be added
+    with any type."""
+    stored_fields = _fields_by_name(stored_schema)
+    retyped = []
+    for name, incoming in _fields_by_name(incoming_schema).items():
+        original = stored_fields.get(name)
+        if original is None:
+            continue
+        if (incoming.get("type") or "") != (original.get("type") or ""):
+            retyped.append(name)
+    return retyped
+
 
 class AircanPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IConfigDeclaration)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IAuthFunctions)
+    plugins.implements(plugins.IResourceController, inherit=True)
     plugins.implements(plugins.IDomainObjectModification)
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.ITemplateHelpers)
@@ -68,6 +119,51 @@ class AircanPlugin(plugins.SingletonPlugin):
         declaration.declare(key.ckanext.aircan.s3.key_prefix)
         declaration.declare(key.ckanext.aircan.s3.endpoint_url)
         declaration.declare(key.ckanext.aircan.s3.region)
+
+    # IResourceController
+    def before_resource_update(self, context, current, resource):
+        """Reject a type change to an existing datastore column when ingesting
+        with append/upsert.
+
+        BigQuery cannot re-type an existing column in place, so aircan can only
+        honour a type change under "replace" (which rebuilds the table). The
+        frontend already disables the type inputs in this case; this enforces
+        the same rule before the change is committed, so API and harvester
+        callers cannot smuggle a type change past the pipeline.
+        """
+        # Effective mode: the incoming value wins, otherwise the stored one (a
+        # metadata-only patch may not resend it).
+        mode = resource.get("ingestion_mode") or current.get("ingestion_mode")
+        if mode not in _TYPE_LOCKING_MODES:
+            return
+
+        # Only guard resources that already have a datastore table to protect.
+        # aircan sets this flag once a DAG has loaded data (see
+        # update_resource_metadata); without it there is no existing table and
+        # any type is fine.
+        if not current.get("datastore_active"):
+            return
+
+        incoming_schema = _parse_schema(resource.get("schema"))
+        stored_schema = _parse_schema(current.get("schema"))
+        # No incoming schema (e.g. metadata-only update) or no stored schema to
+        # compare against -> nothing to enforce.
+        if incoming_schema is None or stored_schema is None:
+            return
+
+        retyped = _retyped_columns(stored_schema, incoming_schema)
+        if retyped:
+            raise tk.ValidationError(
+                {
+                    "schema": [
+                        tk._(
+                            "Column type cannot be changed for an existing "
+                            "table when the processing mode is '{mode}': {cols}. "
+                            "Use the 'replace' mode to change column types."
+                        ).format(mode=mode, cols=", ".join(sorted(retyped)))
+                    ]
+                }
+            )
 
     # IDomainObjectModification
     def notify(self, entity, operation):

--- a/ckanext/aircan/tests/test_plugin.py
+++ b/ckanext/aircan/tests/test_plugin.py
@@ -8,6 +8,8 @@ import ckan.plugins.toolkit as tk
 import ckan.tests.factories as factories
 from ckan.model.domain_object import DomainObjectOperation
 
+from ckanext.aircan.plugin import AircanPlugin, _parse_schema, _retyped_columns
+
 
 @pytest.mark.ckan_config("ckan.plugins", "aircan")
 @pytest.mark.usefixtures("with_plugins")
@@ -76,3 +78,95 @@ class TestAutoSubmit:
         resource = factories.Resource(package_id=dataset["id"], format="CSV")
 
         assert resource["id"]
+
+
+class TestParseSchema:
+    def test_accepts_dict(self):
+        schema = {"fields": [{"name": "a", "type": "integer"}]}
+        assert _parse_schema(schema) == schema
+
+    def test_accepts_json_string(self):
+        assert _parse_schema('{"fields": []}') == {"fields": []}
+
+    @pytest.mark.parametrize(
+        "value", [None, "", {}, [], "not json", "[1, 2]", 5]
+    )
+    def test_returns_none_for_unusable_input(self, value):
+        assert _parse_schema(value) is None
+
+
+class TestRetypedColumns:
+    STORED = {"fields": [{"name": "a", "type": "integer"},
+                         {"name": "b", "type": "string"}]}
+
+    def test_no_change(self):
+        assert _retyped_columns(self.STORED, self.STORED) == []
+
+    def test_detects_changed_type(self):
+        incoming = {"fields": [{"name": "a", "type": "string"},
+                              {"name": "b", "type": "string"}]}
+        assert _retyped_columns(self.STORED, incoming) == ["a"]
+
+    def test_new_column_is_allowed(self):
+        incoming = {"fields": [{"name": "a", "type": "integer"},
+                              {"name": "b", "type": "string"},
+                              {"name": "c", "type": "number"}]}
+        assert _retyped_columns(self.STORED, incoming) == []
+
+    def test_matches_names_after_trimming(self):
+        incoming = {"fields": [{"name": " a ", "type": "string"}]}
+        assert _retyped_columns(self.STORED, incoming) == ["a"]
+
+    def test_dropped_column_is_not_reported(self):
+        incoming = {"fields": [{"name": "b", "type": "string"}]}
+        assert _retyped_columns(self.STORED, incoming) == []
+
+
+class TestTypeLockOnUpdate:
+    """before_resource_update rejects a type change to an existing datastore
+    column under append/upsert, but allows it under replace / for new
+    columns / when there is no existing table."""
+
+    STORED = {"fields": [{"name": "a", "type": "integer"},
+                         {"name": "b", "type": "string"}]}
+    RETYPE = {"fields": [{"name": "a", "type": "string"},
+                        {"name": "b", "type": "string"}]}
+
+    def _run(self, current, resource):
+        AircanPlugin().before_resource_update({}, current, resource)
+
+    @pytest.mark.parametrize("mode", ["append", "upsert"])
+    def test_retype_rejected_for_append_and_upsert(self, mode):
+        current = {"datastore_active": True, "ingestion_mode": mode,
+                   "schema": self.STORED}
+        with pytest.raises(tk.ValidationError) as exc:
+            self._run(current, {"ingestion_mode": mode, "schema": self.RETYPE})
+        assert "schema" in exc.value.error_dict
+
+    def test_retype_allowed_for_replace(self):
+        current = {"datastore_active": True, "ingestion_mode": "replace",
+                   "schema": self.STORED}
+        self._run(current, {"ingestion_mode": "replace", "schema": self.RETYPE})
+
+    def test_retype_allowed_without_existing_table(self):
+        current = {"ingestion_mode": "append", "schema": self.STORED}
+        self._run(current, {"ingestion_mode": "append", "schema": self.RETYPE})
+
+    def test_new_column_allowed_on_append(self):
+        incoming = {"fields": self.STORED["fields"] +
+                    [{"name": "c", "type": "number"}]}
+        current = {"datastore_active": True, "ingestion_mode": "append",
+                   "schema": self.STORED}
+        self._run(current, {"ingestion_mode": "append", "schema": incoming})
+
+    def test_metadata_only_update_allowed(self):
+        current = {"datastore_active": True, "ingestion_mode": "append",
+                   "schema": self.STORED}
+        self._run(current, {"description": "changed"})
+
+    def test_mode_falls_back_to_stored_value(self):
+        # Incoming patch omits the mode; the stored append mode still locks it.
+        current = {"datastore_active": True, "ingestion_mode": "append",
+                   "schema": self.STORED}
+        with pytest.raises(tk.ValidationError):
+            self._run(current, {"schema": self.RETYPE})


### PR DESCRIPTION
Part of datopian/neso-nextgen-shared#139 (AC: "API rejects updating column types if mode is append or upsert").

## What
BigQuery cannot re-type an existing column in place, so aircan can only honour a type change under `replace` (which rebuilds the table). The frontend already disables the type inputs for append/upsert on an existing datastore table, but **API and harvester callers bypassed that**.

## Change
Add an `IResourceController.before_resource_update` hook that rejects a **type change to an existing datastore column** when `ingestion_mode` is `append` or `upsert`:
- fires only when the resource already has a datastore table (`datastore_active`);
- new columns and `replace` are unaffected;
- matches the frontend rule from datopian/neso-nextgen-shared#134.

## Verification
Confirmed via the CKAN HTTP API (`resource_patch`): append/upsert + retype → rejected with a `ValidationError`; replace + retype, new column, and metadata-only updates → accepted. Unit tests added in `tests/test_plugin.py` (helpers + hook matrix); full suite green.

## Notes
- Branched off `v2.0.1` (the deployed tag). The header-character validation (AC II) already lives in ckanext-neso.
- Pairs with aircan + dx-helm-neso PRs (same branch name).