### PR TITLE
Include dataset editor in Aircan payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Example request body used by `aircan_hook` (and/or as the shape of a status/log 
 * **`error`** *(string|null, optional)*: Error details (use `null` when not applicable).
 * **`clear_logs`** *(boolean, optional)*: If `true`, clears existing logs otherwise appends to them keep a history.
 
+Aircan submissions also include `changed_by` when CKAN has an authenticated
+actor. It contains the actor's `id`, `name`, and `email`.
+
 ## Extending Aircan payload 
 You can extend the payload sent to Airflow by implementing the `IAircan` interface in your own CKAN plugin.
 

--- a/ckanext/aircan/logic/action.py
+++ b/ckanext/aircan/logic/action.py
@@ -17,6 +17,32 @@ from ckanext.aircan.lib.airflow import AirflowClient
 log = logging.getLogger(__name__)
 
 
+def _changed_by(context):
+    """Return safe user identity fields for the downstream Airflow payload."""
+    actor = context.get("aircan_actor")
+    if actor:
+        return actor
+
+    user_obj = context.get("auth_user_obj")
+    user_name = context.get("user")
+    user_id = getattr(user_obj, "id", None)
+    email = getattr(user_obj, "email", None)
+
+    if isinstance(user_obj, dict):
+        user_id = user_obj.get("id")
+        user_name = user_name or user_obj.get("name")
+        email = user_obj.get("email")
+
+    if not user_id and not user_name:
+        return None
+
+    return {
+        "id": user_id,
+        "name": user_name or getattr(user_obj, "name", None),
+        "email": email,
+    }
+
+
 def aircan_submit(context, data_dict: Dict[str, Any]) -> Dict[str, Any]:
     """
     Submit a resource to Airflow for processing via Aircan DAG.
@@ -91,6 +117,9 @@ def aircan_submit(context, data_dict: Dict[str, Any]) -> Dict[str, Any]:
             "region": tk.config.get("ckanext.aircan.s3.region"),
         },
     }
+    changed_by = _changed_by(context)
+    if changed_by:
+        payload["changed_by"] = changed_by
 
     for plugin in plugins.PluginImplementations(interfaces.IAircan):
         plugin.update_payload(context, payload)

--- a/ckanext/aircan/plugin.py
+++ b/ckanext/aircan/plugin.py
@@ -195,7 +195,24 @@ class AircanPlugin(plugins.SingletonPlugin):
                 "id": entity.id,
             },
         )
-        self._self_aircan_submit(resource_dict)
+        self._self_aircan_submit(resource_dict, self._current_actor())
+
+    @staticmethod
+    def _current_actor():
+        """Capture safe identity fields before the commit hook loses context."""
+        user_obj = getattr(tk.c, "userobj", None)
+        user_name = getattr(tk.c, "user", None)
+        user_id = getattr(user_obj, "id", None)
+        email = getattr(user_obj, "email", None)
+
+        if not user_id and not user_name:
+            return None
+
+        return {
+            "id": user_id,
+            "name": user_name or getattr(user_obj, "name", None),
+            "email": email,
+        }
 
     # CKAN can notify the same resource more than once per request: on file
     # uploads the new resource ends up in both the "new" and "changed" object
@@ -217,7 +234,7 @@ class AircanPlugin(plugins.SingletonPlugin):
         self._recent_submissions[resource_id] = now
         return False
 
-    def _self_aircan_submit(self, resource_dict):
+    def _self_aircan_submit(self, resource_dict, actor=None):
         """
         Submit the resource to Aircan for processing.
 
@@ -239,6 +256,8 @@ class AircanPlugin(plugins.SingletonPlugin):
             return
 
         context = {"ignore_auth": True, "defer_commit": True}
+        if actor:
+            context["aircan_actor"] = actor
         try:
             tk.get_action("aircan_submit")(context, resource_dict)
         except Exception:

--- a/ckanext/aircan/plugin.py
+++ b/ckanext/aircan/plugin.py
@@ -200,8 +200,13 @@ class AircanPlugin(plugins.SingletonPlugin):
     @staticmethod
     def _current_actor():
         """Capture safe identity fields before the commit hook loses context."""
-        user_obj = getattr(tk.c, "userobj", None)
-        user_name = getattr(tk.c, "user", None)
+        try:
+            user_obj = getattr(tk.c, "userobj", None)
+            user_name = getattr(tk.c, "user", None)
+        except RuntimeError:
+            # Domain modification callbacks can run outside a request context.
+            return None
+
         user_id = getattr(user_obj, "id", None)
         email = getattr(user_obj, "email", None)
 


### PR DESCRIPTION
## Summary\n- include safe editor identity fields in Aircan submissions\n- preserve the actor for automatic resource-change submissions\n- document the changed_by payload field\n\n## Validation\n- python -m compileall -q ckanext\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Aircan submissions now include authenticated actor details—ID, name, and email—when available.
  * Resource auto-submissions preserve the actor information associated with the change.
* **Documentation**
  * Updated endpoint documentation to describe the new `changed_by` submission field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->