### PR TITLE
feat: support package validation opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ ckanext.aircan.gcs.signed_url_expiration_seconds = 3600
 ckanext.aircan.chunk_size = 104857600
 ckanext.aircan.skip_leading_rows = 1
 ckan.aircan.temp_table_prefix = _temp_
+ckanext.aircan.validate_records = true
 ckanext.aircan.notification_to_email = ops@example.com editor
 ckanext.aircan.notification_from_email =
 
@@ -116,6 +117,10 @@ Example request body used by `aircan_hook` (and/or as the shape of a status/log 
 `ckanext.aircan.notification_to_email` accepts whitespace-separated addresses.
 Add the `editor` token to notify the authenticated user who changed the dataset;
 the token is replaced by that user's email in the Aircan submission.
+
+When validation is enabled globally, a dataset may opt out by setting its
+`aircan_validate_records` metadata field to `false`. Missing metadata defaults
+to enabled, and a dataset cannot enable validation when it is disabled globally.
 
 ## Extending Aircan payload 
 You can extend the payload sent to Airflow by implementing the `IAircan` interface in your own CKAN plugin.

--- a/ckanext/aircan/logic/action.py
+++ b/ckanext/aircan/logic/action.py
@@ -32,6 +32,21 @@ def _notification_email(context):
     return email
 
 
+def _validate_records_enabled(context, data_dict: Dict[str, Any]) -> bool:
+    globally_enabled = tk.asbool(
+        tk.config.get("ckanext.aircan.validate_records", True)
+    )
+    package_id = data_dict.get("package_id")
+    if not globally_enabled or not package_id:
+        return globally_enabled
+
+    package = tk.get_action("package_show")(context, {"id": package_id})
+    package_setting = package.get("aircan_validate_records")
+    if package_setting in (None, ""):
+        return True
+    return tk.asbool(package_setting)
+
+
 def aircan_submit(context, data_dict: Dict[str, Any]) -> Dict[str, Any]:
     """
     Submit a resource to Airflow for processing via Aircan DAG.
@@ -89,9 +104,7 @@ def aircan_submit(context, data_dict: Dict[str, Any]) -> Dict[str, Any]:
                 tk.config.get("ckanext.aircan.notification_to_email") or ""
             ).split()
             or [],
-            "validate_records": tk.asbool(
-                tk.config.get("ckanext.aircan.validate_records", True)
-            ),
+            "validate_records": _validate_records_enabled(context, data_dict),
             "notification_from_email": tk.config.get(
                 "ckanext.aircan.notification_from_email"
             ),

--- a/ckanext/aircan/tests/logic/test_action.py
+++ b/ckanext/aircan/tests/logic/test_action.py
@@ -8,6 +8,42 @@ from werkzeug.exceptions import HTTPException
 import ckan.plugins.toolkit as tk
 import ckan.tests.factories as factories
 import ckan.tests.helpers as test_helpers
+from ckanext.aircan.logic import action
+
+
+@pytest.mark.parametrize(
+    ("global_value", "package_value", "expected"),
+    [
+        (True, "true", True),
+        (True, "false", False),
+        (True, None, True),
+        (False, "true", False),
+    ],
+)
+def test_validate_records_enabled(
+    monkeypatch, global_value, package_value, expected
+):
+    monkeypatch.setattr(
+        action.tk.config,
+        "get",
+        lambda key, default=None: global_value
+        if key == "ckanext.aircan.validate_records"
+        else default,
+    )
+
+    def package_show(_context, _data_dict):
+        return {"aircan_validate_records": package_value}
+
+    monkeypatch.setattr(
+        action.tk,
+        "get_action",
+        lambda name: package_show if name == "package_show" else None,
+    )
+
+    assert (
+        action._validate_records_enabled({}, {"package_id": "package-id"})
+        is expected
+    )
 
 
 @pytest.mark.ckan_config("ckan.plugins", "aircan")


### PR DESCRIPTION
## Summary
- derive `others_config.validate_records` from global configuration and parent package metadata
- default missing package metadata to enabled for backward compatibility
- document precedence and add focused tests

## Validation
- `pytest -o addopts='' ckanext/aircan/tests/logic/test_action.py -k validate_records_enabled` (4 passed)
- `git diff --check`